### PR TITLE
Mitigate universe constraints -- see Compiler.v

### DIFF
--- a/backend/RTLgenproof.v
+++ b/backend/RTLgenproof.v
@@ -1118,8 +1118,8 @@ Fixpoint size_cont (k: cont) : nat :=
 
 Definition measure_state (S: CminorSel.state) :=
   match S with
-  | CminorSel.State _ s k _ _ _ => (size_stmt s + size_cont k, size_stmt s)
-  | _                           => (0, 0)
+  | CminorSel.State _ s k _ _ _ => (ppair (size_stmt s + size_cont k) (size_stmt s))
+  | _                           => (ppair 0 0)
   end.
 
 Definition lt_state (S1 S2: CminorSel.state) :=

--- a/driver/Compiler.v
+++ b/driver/Compiler.v
@@ -491,3 +491,7 @@ Proof.
   destruct H2 as (asm_program & P & Q).
   exists asm_program; split; auto. apply c_semantic_preservation; auto.
 Qed.
+
+Let __marker__ := tt.
+Constraint prod.u0 < forward_simulation.u0.
+Reset __marker__.

--- a/lib/Coqlib.v
+++ b/lib/Coqlib.v
@@ -1265,17 +1265,19 @@ Variable B: Type.
 Variable ordA: A -> A -> Prop.
 Variable ordB: B -> B -> Prop.
 
-Inductive lex_ord: A*B -> A*B -> Prop :=
+Record pprod: Type := ppair { pfst: A ; psnd: B }.
+
+Inductive lex_ord: pprod -> pprod -> Prop :=
   | lex_ord_left: forall a1 b1 a2 b2,
-      ordA a1 a2 -> lex_ord (a1,b1) (a2,b2)
+      ordA a1 a2 -> lex_ord (ppair a1 b1) (ppair a2 b2)
   | lex_ord_right: forall a b1 b2,
-      ordB b1 b2 -> lex_ord (a,b1) (a,b2).
+      ordB b1 b2 -> lex_ord (ppair a b1) (ppair a b2).
 
 Lemma wf_lex_ord:
   well_founded ordA -> well_founded ordB -> well_founded lex_ord.
 Proof.
   intros Awf Bwf.
-  assert (forall a, Acc ordA a -> forall b, Acc ordB b -> Acc lex_ord (a, b)).
+  assert (forall a, Acc ordA a -> forall b, Acc ordB b -> Acc lex_ord (ppair a b)).
     induction 1. induction 1. constructor; intros. inv H3.
     apply H0. auto. apply Bwf.
     apply H2; auto.

--- a/lib/Postorder.v
+++ b/lib/Postorder.v
@@ -295,12 +295,12 @@ Fixpoint size_worklist (w: list (positive * list positive)) : nat :=
   end.
 
 Definition lt_state (s1 s2: state) : Prop :=
-  lex_ord lt lt (PTree_Properties.cardinal s1.(gr), size_worklist s1.(wrk))
-                (PTree_Properties.cardinal s2.(gr), size_worklist s2.(wrk)).
+  lex_ord lt lt (ppair (PTree_Properties.cardinal s1.(gr)) (size_worklist s1.(wrk)))
+                (ppair (PTree_Properties.cardinal s2.(gr)) (size_worklist s2.(wrk))).
 
 Lemma lt_state_wf: well_founded lt_state.
 Proof.
-  set (f := fun s => (PTree_Properties.cardinal s.(gr), size_worklist s.(wrk))).
+  set (f := fun s => (ppair (PTree_Properties.cardinal s.(gr)) (size_worklist s.(wrk)))).
   change (well_founded (fun s1 s2 => lex_ord lt lt (f s1) (f s2))).
   apply wf_inverse_image.
   apply wf_lex_ord.


### PR DESCRIPTION
(Detailed history)
Commit: https://github.com/alxest/CompCertM/tree/51e0d93e6b7fcd6c07dd65031c64770aae05e51c
File: `specIR/SIRBCE2.v`

The problematic cycle:
```
compcomp.SimSIR.253 <= compcomp.Ord.66 <= Ord.idx.u0 = Ord.ord.u0 <
GENMT.mixed_to_backward_simulation.u0 <=
backward_to_compcert_backward_simulation.u0 <= NOSTUTTER.to_compcert_backward_simulation.u0 <=
Smallstep.backward_simulation.u0 <= compcert.common.Smallstep.1926 <=
compcert.lib.Coqlib.458 <= prod.u0 <=
cons_app.u0 <= app.u0 <= list.u0 <= compcomp.SIRBCE2.49 
```
I made Ord.v universe polymorphic, but still problematic:
```
compcomp.SimSIR.253 <=
fsim_step.u0 < mixed_simulation.u0 <=
compcomp.Simulation.1074 <= NOSTUTTER.backward_simulation.u0 <=
Smallstep.backward_simulation.u0 <= compcert.common.Smallstep.1926 <=
compcert.lib.Coqlib.458 (lex_ord) <=
prod.u0 <= cons_app.u0 <= app.u0 <= list.u0 <= compcomp.SIRBCE2.49
```

Understanding error message:
Q: what is Ord.ord.u0? Why `<` happens there? Isn't it the one to blame?
A: 
```
Set Printing Universes.
Require Import Ord.
Fail Constraint idx.u0 < ord.u0.
(*** Universe inconsistency. Cannot enforce idx.u0 < ord.u0 because ord.u0 = ord.u0 = idx.u0. ***)
```
Here we see `ord.u0` is `idx.u0`, which is defined here:
```
Record idx : Type@{max(Set+1,idx.u0+1)} := mk
  { local_idx : Type@{idx.u0};
    local_ord : local_idx -> local_idx -> Prop;
    wf_local_ord : well_founded local_ord;
    elem : local_idx }
```

What is going on here is that we use `idx` as an index of simulation index, so we get `idx's univ <= simulation's index` as a constraint.
Now see that `idx's univ` is `max(Set+1,idx.u0+1)`, and choosing `idx.u0+1` implies `idx.u0 < simulation's index`.
This is where `<` was introduced, and it seems sensible.

---------------------------------------

Q: Then who is to blame?
A: Not entirely clear, but I think if we can remove `simulation's index <= prod.u0` constraint, this would be beneficial for all users of the simulation definition. And it turns out we can actually remove it (by defining another product type).

---------------------------------------

Q: Why not universe polymorphism on pair type? (polymorphic pair)
A: I tried it, but it gives an arcane error that cannot be handled.
